### PR TITLE
debControlMerger: handle alternative dependencies

### DIFF
--- a/deb/controlfileparser.py
+++ b/deb/controlfileparser.py
@@ -409,13 +409,26 @@ class ControlFileParser(object):
         end_line = lines[position.end_line - 1]
         end_char = position.end_char
 
+        # If this is the right-hand side of an OR, drop the | but preserve
+        # any following comma.
+        if start_line[start_char - 4:start_char - 1] == ' | ':
+            start_char -= 3
         # If followed by a comma, remove that too
-        if len(end_line) > end_char and end_line[end_char] == ',':
+        elif len(end_line) > end_char and end_line[end_char] == ',':
             end_char += 1
 
         # If followed by whitespace, remove that too
         while len(end_line) > end_char and end_line[end_char].isspace():
             end_char += 1
+
+        # If this is the left-hand side of an OR, drop the | and any following
+        # whitespace.
+        if len(end_line) > end_char and end_line[end_char] == '|':
+            end_char += 1
+            while len(end_line) > end_char and end_line[end_char].isspace():
+                end_char += 1
+
+        position.start_char = start_char
         position.end_char = end_char
 
         # If everything else on the line is empty or whitespace, then just

--- a/tests/debControlMergerTests.py
+++ b/tests/debControlMergerTests.py
@@ -9,10 +9,11 @@ from util.debcontrolmerger import DebControlMerger
 
 class DebControlMergerTest(unittest.TestCase):
     def setUp(self):
-        self.base_dir = mkdtemp(prefix='mom.control_test.base.')
-        self.left_dir = mkdtemp(prefix='mom.control_test.left.')
-        self.right_dir = mkdtemp(prefix='mom.control_test.right.')
-        self.merged_dir = mkdtemp(prefix='mom.control_test.merged.')
+        self.parent_dir = mkdtemp(prefix='mom.control_test.')
+        self.base_dir   = os.path.join(self.parent_dir, 'base')
+        self.left_dir   = os.path.join(self.parent_dir, 'left')
+        self.right_dir  = os.path.join(self.parent_dir, 'right')
+        self.merged_dir = os.path.join(self.parent_dir, 'merged')
 
         os.makedirs(self.base_dir + '/debian')
         os.makedirs(self.left_dir + '/debian')
@@ -26,10 +27,7 @@ class DebControlMergerTest(unittest.TestCase):
 
     def tearDown(self):
         if testhelper.should_cleanup():
-            shutil.rmtree(self.base_dir)
-            shutil.rmtree(self.left_dir)
-            shutil.rmtree(self.right_dir)
-            shutil.rmtree(self.merged_dir)
+            shutil.rmtree(self.parent_dir)
 
     def write_control(self, path, contents):
         with open(path, 'w') as fd:

--- a/tests/debControlMergerTests.py
+++ b/tests/debControlMergerTests.py
@@ -44,7 +44,7 @@ class DebControlMergerTest(unittest.TestCase):
 
     def assertResult(self, result):
         with open(self.merged_path, 'r') as fd:
-            self.assertEqual(fd.read(), result)
+            self.assertMultiLineEqual(fd.read(), result)
 
     def merge(self):
         merger = DebControlMerger('debian/control',


### PR DESCRIPTION
Depends and similar fields are not, strictly speaking, lists of packages: they are lists of alternatives. However, the parser currently flattens `a, b | c` to `a, b, c` when considering whether a dependency has been dropped downstream.

Previously, this meant that lines like these:

    rustc [i386 amd64] <!nocheck> | bash-doc <!nocheck>,

could be patched to:

    | bash-doc <!nocheck>,

which is syntactically invalid. Reparsing the patched file would then fail.

Special-case this in `__remove_list_entry()`. It's not pretty but it does allow the merge to proceed. (Unfortunately, with the real control file the merge ultimately fails for a different reason, but it's better than crashing.)

I'm not especially happy with this. It feels like a real hack. A better approach might be to store a pointer from each branch of an alternative back to the alternative, but it's not immediately clear what this should look like.

https://phabricator.endlessm.com/T27553