### PR TITLE
Add missing debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends:
  osc,
  patch,
  patchutils,
+ python-apt,
  python-pychart,
  python-jinja2,
  python (>=2.7),

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Depends:
  apache2 | httpd,
  cron,
  diffstat,
+ diffutils,
  dpkg-dev,
  logrotate,
  osc,

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Depends:
  diffstat,
  diffutils,
  dpkg-dev,
+ gettext,
  logrotate,
  osc,
  patch,

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Depends:
  logrotate,
  osc,
  patch,
+ patchutils,
  python-pychart,
  python-jinja2,
  python (>=2.7),

--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,8 @@ Depends:
  python-pychart,
  python-jinja2,
  python (>=2.7),
- quilt
+ quilt,
+ tar,
 Description: Merge-o-Matic
  Merge-o-Matic is an automated merge system (also known as "mom").
  .

--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Depends:
  dpkg-dev,
  logrotate,
  osc,
+ patch,
  python-pychart,
  python-jinja2,
  python (>=2.7),

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Depends:
  apache2 | httpd,
  cron,
  diffstat,
+ dpkg-dev,
  logrotate,
  osc,
  python-pychart,


### PR DESCRIPTION
In preparation for moving m-o-m to AWS, the install needs to be repeatable. This adds all the missing dependencies I could find in the source. After this I believe the only missing dependency is on lark.

https://phabricator.endlessm.com/T27614