### PR TITLE
debian: Add dependency on python-lark

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Depends:
  patch,
  patchutils,
  python-apt,
+ python-lark,
  python-pychart,
  python-jinja2,
  python (>=2.7),


### PR DESCRIPTION
This is using the Endless packaged version of lark in the OBS infra:*
projects.

https://phabricator.endlessm.com/T27614