### PR TITLE
Support numbers in Depends/Build-Depends fields

### DIFF
--- a/deb/deplist.lark
+++ b/deb/deplist.lark
@@ -3,7 +3,7 @@ start: ","? _WS? or_dep ("," _WS? or_dep)* ","? _WS?
 _WS: /[ \t]+/
 
 pkg_name: /[a-zA-Z0-9-+._]+/ (":" /[a-zA-Z0-9-+._]+/)?
-	| "${" /[a-zA-Z:]+/ "}"
+	| "${" /[a-zA-Z0-9:]+/ "}"
 version_constraint: /[^)]+/
 arch_list: /[a-zA-Z0-9-_! ]+/
 profile_list: /[a-zA-Z0-9-_.! ]+/


### PR DESCRIPTION
Add support for tokens containing numbers in the package dependency
fields, like ${python3:Depends}.

This fixes the following error when trying to merge checkbox-ng:

 This package could not be merged: UnexpectedCharacters: No terminal
 defined for '3' at line 1 col 9 ${python3:Depends} ^ Expecting:
 set([u'RBRACE']) Previous tokens: Token(__ANON_2, u'python') . Please
 carry out a manual merge and commit the result.

https://phabricator.endlessm.com/T28633